### PR TITLE
Support self- and forward references

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-pip
       - run: pip install -e '.[test]'
       - run: coverage run -m pytest
-      - run: coverage report && coverage xml
+      - run: coverage report -m && coverage xml
       - name: Report coverage
         uses: codecov/codecov-action@v2
         with:

--- a/abcattrs/abcattrs.py
+++ b/abcattrs/abcattrs.py
@@ -16,7 +16,11 @@ Abstract = Annotated[_O, _abstract_marker]
 
 
 def get_abstract_attributes(cls: type) -> Iterable[Tuple[str, type]]:
-    hints = get_type_hints(cls, include_extras=True)
+    hints = get_type_hints(
+        cls,
+        include_extras=True,
+        localns={cls.__name__: cls},
+    )
     for var, hint in hints.items():
         # Checking for both the abstract marker and the type alias itself allows both
         # a concise way using e.g. `var: Abstract[int]` and a way to combine the

--- a/abcattrs/type_hints.py
+++ b/abcattrs/type_hints.py
@@ -1,0 +1,34 @@
+from typing import Final
+from typing import ForwardRef
+from typing import get_type_hints
+
+max_iterations: Final = 10_000
+
+
+class MaxIterations(RuntimeError):
+    ...
+
+
+def get_name_error_name(error: NameError) -> str:
+    return str(error).split("'", 2)[1]
+
+
+def get_resolvable_type_hints(cls: type) -> dict[str, type]:
+    """
+    Repeatedly attempt to resolve the type hints of the given class, handling the
+    NameErrors produced by unresolvable names by inserting sentinel typing.ForwardRef
+    objects.
+    """
+    local_ns = {cls.__name__: cls}
+
+    for _ in range(max_iterations):
+        try:
+            return get_type_hints(cls, include_extras=True, localns=local_ns)
+        except NameError as exception:
+            name = get_name_error_name(exception)
+            local_ns[name] = ForwardRef(name)  # type: ignore[assignment]
+    else:
+        raise MaxIterations(
+            f"Exceeded {max_iterations} iterations trying to resolve type hints of "
+            f"{cls.__module__}.{cls.__qualname__}."
+        )

--- a/abcattrs/type_hints.py
+++ b/abcattrs/type_hints.py
@@ -27,7 +27,7 @@ def get_resolvable_type_hints(cls: type) -> dict[str, type]:
         except NameError as exception:
             name = get_name_error_name(exception)
             local_ns[name] = ForwardRef(name)  # type: ignore[assignment]
-    else:
+    else:  # pragma: no cover
         raise MaxIterations(
             f"Exceeded {max_iterations} iterations trying to resolve type hints of "
             f"{cls.__module__}.{cls.__qualname__}."

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,6 +1,5 @@
 import abc
 from typing import Annotated
-from typing import get_type_hints
 from unittest import mock
 
 import pytest
@@ -106,13 +105,13 @@ def test_existing_init_subclass_method_is_wrapped() -> None:
 def test_can_decorate_class_with_self_reference() -> None:
     @abstractattrs
     class A(abc.ABC):
-        recursive: Abstract["A"]
+        recursive: Abstract["A"]  # noqa: F821
 
 
 def test_can_decorate_class_with_forward_reference() -> None:
     @abstractattrs
     class A(abc.ABC):
-        forward: Abstract["B"]
+        forward: Abstract["B"]  # noqa: F821
 
     class B:
         ...

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Annotated
+from typing import Annotated, get_type_hints
 from unittest import mock
 
 import pytest
@@ -100,3 +100,21 @@ def test_existing_init_subclass_method_is_wrapped() -> None:
         attr = 1
 
     init_subclass.assert_called_once_with(C, class_arg="intact")
+
+
+def test_can_decorate_class_with_self_reference() -> None:
+    @abstractattrs
+    class A(abc.ABC):
+        recursive: Abstract["A"]
+
+    # These checks might not add much value, I consider them more like smoke tests ...
+    with pytest.raises(UndefinedAbstractAttribute):
+        type("B", (A,), {})
+
+    class C(A):
+        @property
+        def recursive(self) -> A:
+            return C()
+
+    c = C()
+    assert isinstance(c.recursive, C)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -13,6 +13,7 @@ from abcattrs import check_abstract_class_attributes
 def test_base_class_saves_attributes() -> None:
     @abstractattrs
     class A(abc.ABC):
+        bar: int
         foo: Abstract[int]
 
     assert not {"foo"} ^ A.__abstract_attributes__  # type: ignore[attr-defined]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -107,14 +107,14 @@ def test_can_decorate_class_with_self_reference() -> None:
     class A(abc.ABC):
         recursive: Abstract["A"]
 
-    # These checks might not add much value, I consider them more like smoke tests ...
-    with pytest.raises(UndefinedAbstractAttribute):
-        type("B", (A,), {})
+
+def test_can_decorate_class_with_forward_reference() -> None:
+    @abstractattrs
+    class A(abc.ABC):
+        forward: Abstract["B"]
+
+    class B:
+        ...
 
     class C(A):
-        @property
-        def recursive(self) -> A:
-            return C()
-
-    c = C()
-    assert isinstance(c.recursive, C)
+        forward = B()

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,5 +1,6 @@
 import abc
-from typing import Annotated, get_type_hints
+from typing import Annotated
+from typing import get_type_hints
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
This addresses #1, though I think this is not enough as a general solution: it only deals with recursive references, not "real" forward references, e.g.:


```
@dec
class A:
    b: B
class B:
    ...
```

A more viable solution _might_ be to not resolve hints at decoration-time, but only store the `__annotations__`. As long as forward references are resolvable when `__init_subclass__` is invoked, that might work ... 🤔