### PR TITLE
Fix premature check on abstract class

### DIFF
--- a/abcattrs/abcattrs.py
+++ b/abcattrs/abcattrs.py
@@ -1,4 +1,5 @@
 import abc
+import inspect
 from collections.abc import Callable
 from collections.abc import Iterable
 from functools import partial
@@ -70,7 +71,7 @@ class UndefinedAbstractAttribute(TypeError):
 
 def check_abstract_class_attributes(cls: type) -> None:
     """Check that a class defines inherited abstract attributes."""
-    if abc.ABC in cls.__bases__:
+    if inspect.isabstract(cls) or abc.ABC in cls.__bases__:
         return
 
     for attr in getattr(cls, "__abstract_attributes__", ()):

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,3 +73,9 @@ force_single_line = True
 
 [tool:pytest]
 addopts = --mypy-ini-file=setup.cfg
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    # ignore non-implementations
+    ^\s*\.\.\.

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -138,3 +138,16 @@ def test_can_decorate_class_with_forward_reference() -> None:
 
     class C(A):
         forward = B()
+
+
+def test_does_not_interpret_abstract_subclass_as_concrete() -> None:
+    @abstractattrs
+    class A(abc.ABC):
+        attr: Abstract[int]
+
+        @abc.abstractmethod
+        def foo(self) -> None:
+            ...
+
+    class B(A):
+        ...


### PR DESCRIPTION
`@abstractattrs` check shouldn't interpret an abstract class as concrete. We're now checking if a class is abstract before verifying abstract attributes.

I'm aware that there's a discrepancy here. If there's no methods decorated as `@abstractmethod` and we only have `@abstractattrs` we'll still need to inherit `abc.ABC` on each subclass.

However, this change still covers some additional cases

Closes #22 