### PR TITLE
Adding Python 3.8 and 3.9 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - abc_attrs_pullversion
   workflow_dispatch:
   pull_request:
 
@@ -41,3 +42,5 @@ jobs:
           file: coverage.xml
           fail_ci_if_error: true
           name: codecov-py${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py310-plus
+          - --py38-plus
   - repo: https://github.com/myint/autoflake
     rev: "v2.0.1"
     hooks:

--- a/abcattrs/abcattrs.py
+++ b/abcattrs/abcattrs.py
@@ -10,7 +10,10 @@ from .typing_redirect import Any
 from .typing_redirect import Callable
 from .typing_redirect import Final
 from .typing_redirect import Iterable
+from .typing_redirect import Tuple
+from .typing_redirect import Type
 from .typing_redirect import TypeVar
+from .typing_redirect import Union
 from .typing_redirect import get_args
 
 _abstract_marker: Final = object()
@@ -18,7 +21,7 @@ _O = TypeVar("_O")
 Abstract = Annotated[_O, _abstract_marker]
 
 
-def get_abstract_attributes(cls: type) -> Iterable[tuple[str, type]]:
+def get_abstract_attributes(cls: type) -> Iterable[Tuple[str, type]]:
     for var, hint in get_resolvable_type_hints(cls).items():
         annotated = extract_annotated(hint)
         if not annotated:
@@ -31,7 +34,7 @@ def get_abstract_attributes(cls: type) -> Iterable[tuple[str, type]]:
             yield var, annotated
 
 
-C = TypeVar("C", bound=type[abc.ABC])
+C = TypeVar("C", bound=Type[abc.ABC])
 
 
 def abstractattrs(cls: C) -> C:
@@ -84,7 +87,7 @@ def check_abstract_class_attributes(cls: type) -> None:
 
 def _init_subclass(
     cls: type,
-    existing_init_subclass: Callable[..., None] | None = None,
+    existing_init_subclass: Union[Callable[..., None], None] = None,
     *args: Any,
     **kwargs: Any,
 ) -> None:

--- a/abcattrs/abcattrs.py
+++ b/abcattrs/abcattrs.py
@@ -1,17 +1,17 @@
 import abc
 import inspect
-from collections.abc import Callable
-from collections.abc import Iterable
 from functools import partial
 from functools import wraps
-from typing import Annotated
-from typing import Any
-from typing import Final
-from typing import TypeVar
-from typing import get_args
 
 from .type_hints import extract_annotated
 from .type_hints import get_resolvable_type_hints
+from .typing_redirect import Annotated
+from .typing_redirect import Any
+from .typing_redirect import Callable
+from .typing_redirect import Final
+from .typing_redirect import Iterable
+from .typing_redirect import TypeVar
+from .typing_redirect import get_args
 
 _abstract_marker: Final = object()
 _O = TypeVar("_O")

--- a/abcattrs/type_hints.py
+++ b/abcattrs/type_hints.py
@@ -1,7 +1,9 @@
 from .typing_redirect import Annotated
 from .typing_redirect import ClassVar
+from .typing_redirect import Dict
 from .typing_redirect import Final
 from .typing_redirect import ForwardRef
+from .typing_redirect import Union
 from .typing_redirect import get_args
 from .typing_redirect import get_origin
 from .typing_redirect import get_type_hints
@@ -17,7 +19,7 @@ def get_name_error_name(error: NameError) -> str:
     return str(error).split("'", 2)[1]
 
 
-def get_resolvable_type_hints(cls: type) -> dict[str, type]:
+def get_resolvable_type_hints(cls: type) -> Dict[str, type]:
     """
     Repeatedly attempt to resolve the type hints of the given class, handling the
     NameErrors produced by unresolvable names by inserting sentinel typing.ForwardRef
@@ -38,7 +40,7 @@ def get_resolvable_type_hints(cls: type) -> dict[str, type]:
         )
 
 
-def extract_annotated(hint: type) -> type | None:
+def extract_annotated(hint: type) -> Union[type, None]:
     # Unwrap ClassVar[T] -> T.
     if get_origin(hint) is ClassVar:
         try:

--- a/abcattrs/type_hints.py
+++ b/abcattrs/type_hints.py
@@ -1,10 +1,10 @@
-from typing import Annotated
-from typing import ClassVar
-from typing import Final
-from typing import ForwardRef
-from typing import get_args
-from typing import get_origin
-from typing import get_type_hints
+from .typing_redirect import Annotated
+from .typing_redirect import ClassVar
+from .typing_redirect import Final
+from .typing_redirect import ForwardRef
+from .typing_redirect import get_args
+from .typing_redirect import get_origin
+from .typing_redirect import get_type_hints
 
 max_iterations: Final = 10_000
 

--- a/abcattrs/typing_redirect.py
+++ b/abcattrs/typing_redirect.py
@@ -1,0 +1,43 @@
+import sys
+from typing import Callable
+from typing import ClassVar
+from typing import Dict
+from typing import Final
+from typing import ForwardRef
+from typing import Iterable
+from typing import Tuple
+from typing import Type
+from typing import Union
+
+if sys.version_info < (3, 9):
+    from typing_extensions import Annotated
+    from typing_extensions import Any
+    from typing_extensions import TypeVar
+    from typing_extensions import get_args
+    from typing_extensions import get_origin
+    from typing_extensions import get_type_hints
+else:
+    from typing import Annotated
+    from typing import Any
+    from typing import TypeVar
+    from typing import get_args
+    from typing import get_origin
+    from typing import get_type_hints
+
+__all__ = [
+    "Annotated",
+    "Any",
+    "Callable",
+    "ClassVar",
+    "Dict",
+    "Final",
+    "ForwardRef",
+    "Iterable",
+    "Tuple",
+    "Type",
+    "TypeVar",
+    "Union",
+    "get_args",
+    "get_origin",
+    "get_type_hints",
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,9 @@ url = https://github.com/antonagestam/abcattrs/
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.10
+python_requires = >=3.8
+install_requires =
+    typing-extensions ; python_version < "3.10"
 
 [options.package_data]
 abcattrs = py.typed

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,4 @@
 import abc
-from typing import Annotated
-from typing import Any
-from typing import ClassVar
 from unittest import mock
 
 import pytest
@@ -10,6 +7,9 @@ from abcattrs import Abstract
 from abcattrs import UndefinedAbstractAttribute
 from abcattrs import abstractattrs
 from abcattrs import check_abstract_class_attributes
+from abcattrs.typing_redirect import Annotated
+from abcattrs.typing_redirect import Any
+from abcattrs.typing_redirect import ClassVar
 
 
 def test_base_class_saves_attributes() -> None:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -93,7 +93,7 @@ def test_concrete_multiple_subclass_raises_for_all_missing_attributes() -> None:
     ):
         type("D", (B,), valid_b)
 
-    type("E", (B,), valid_a | valid_b)
+    type("E", (B,), {**valid_a, **valid_b})  # type: ignore[arg-type]
 
 
 def test_can_check_class_without_abstract_class_attributes() -> None:


### PR DESCRIPTION
Adding Python 3.8 and 3.9 support via (version-dependent) `typing-extensions` dependency and replacing certain keywords/operators that were not yet introduced.

There are an additional two changes to `CI.yaml` (the addition of a CodeCov key and the addition of a working branch to the lists of branches that tests get run on) that may warrant removal during the merge.

We may also wish to downgrade some of the mypy/etc versioning, but in the interest of minimizing changes to the codebase with this pull, "if it ain't broke, not fixing it".